### PR TITLE
display incidence with point instead of comma and as float

### DIFF
--- a/custom_components/corona_germany/sensor.py
+++ b/custom_components/corona_germany/sensor.py
@@ -117,7 +117,7 @@ class CoronaSensor(Entity):
 
                 json_data = json.loads(raw_html)
             
-                incidenceTemp = str(round(float(json_data['features'][0]['attributes']['cases7_per_100k']),2)).replace('.',',')
+                incidenceTemp = float(round(float(json_data['features'][0]['attributes']['cases7_per_100k']),2))
 
                 self.attrs[ATTR_INCIDENCE] = incidenceTemp
                 self.attrs[ATTR_DEATHS] = json_data['features'][0]['attributes']['deaths'],


### PR DESCRIPTION
Number automations wont work otherwise: 
Error initializing 'Corona Automation' trigger: In 'numeric_state' condition: entity sensor.coronavirus_mylocation state '111,57' cannot be processed as a number

The "." and "," seem to have nothing to do with the badge being displayed as a graph. 
For me I dont get a graph with both (.) and (,) .
You can check that at the JEK Server.